### PR TITLE
Testing forms

### DIFF
--- a/src/Containers/PaletteForm/PaletteForm.js
+++ b/src/Containers/PaletteForm/PaletteForm.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { addPalette } from '../../actions/index';
 import './PaletteForm.scss';
 
-const PaletteForm = ({ addPalette }) => {
+export const PaletteForm = ({ addPalette }) => {
 
   const [ project, selectProject ] = useState('');
   const [ paletteName, setPalette ] = useState('');
@@ -33,10 +33,11 @@ const PaletteForm = ({ addPalette }) => {
         value={project}
         onChange={ e => selectProject(e.target.value) }
       >
-        <option>One</option>
-        <option>Two</option>
+        <option value='one'>One</option>
+        <option value='two'>Two</option>
       </select>
       <input
+        aria-label='palette-name-input'
         placeholder='Name Your Palette'
         className='palette-name-input'
         type='text'
@@ -44,7 +45,7 @@ const PaletteForm = ({ addPalette }) => {
         value={paletteName}
         onChange={ e => setPalette(e.target.value) }
       />
-      <button className='select-palette-btn' type='button' onClick={ e => handleSubmit(e) }>Save Palette</button>
+      <button className='select-palette-btn' type='button' roll='button' onClick={ e => handleSubmit(e) }>Save Palette</button>
     </form>
   )
 }

--- a/src/Containers/PaletteForm/PaletteForm.test.js
+++ b/src/Containers/PaletteForm/PaletteForm.test.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { PaletteForm, mapDispatchToProps } from './PaletteForm';
+import { addPalette } from '../../actions/index';
+import { render, fireEvent } from '@testing-library/react';
+
+describe('PaletteForm', () => {
+
+  let mockProps, setup
+
+  beforeEach(() => {
+
+    mockProps = {
+      addPalette: jest.fn()
+    }
+
+    setup = () => {
+      const utils = render(<PaletteForm
+        addPalette={mockProps.addPalette}
+      />)
+      const select = utils.getByDisplayValue('select')
+      const input = utils.getByLabelText('palette-name-input')
+      const btn = utils.getByRole('button')
+      return {
+        input,
+        btn,
+        select,
+        ...utils,
+      }
+    }
+  });
+
+  describe('PaletteForm Component', () => {
+
+    test('should match the snapshot', () => {
+      const { utils } = setup();
+  
+      expect(utils).toMatchSnapshot();
+    });
+
+    test('should allow a user to select a project from the drop down')
+  
+  //   test("should load with initial state of '' in the add project input", () => {
+  //     const { input } = setup();
+  //     const inputValue = input;
+  
+  //     expect(inputValue.textContent).toBe('');
+  //   });
+    
+  //   test('should allow a user to input a name', () => {
+  //     const { input } = setup();
+  //     fireEvent.change(input, { target: { value: 'New Project Name'} });
+  
+  //     expect(input.value).toBe('New Project Name')
+  //   });
+  
+  //   test('should reset the input when button is clicked', () => {
+  //     const { input, btn } = setup();
+  //     const inputValue = input;
+  //     fireEvent.change(inputValue, { target: { value: 'New Project Name'} });
+  //     fireEvent.click(btn);
+  
+  //     expect(inputValue.textContent).toBe('')
+  //   });
+  // })
+
+  // describe('mapDispatchToProps', () => {
+
+  //   test('should call mapDispatch with a name when handleLogin is called', () => {
+  //     const mockDispatch = jest.fn();
+  //     const actionToDispatch = addProject({ name: 'Rick' });
+
+  //     const mappedProps = mapDispatchToProps(mockDispatch);
+  //     mappedProps.addProject({ name: 'Rick' });
+
+  //     expect(mockDispatch).toHaveBeenCalledWith(actionToDispatch);
+  //   });
+  });
+});

--- a/src/Containers/PaletteForm/PaletteForm.test.js
+++ b/src/Containers/PaletteForm/PaletteForm.test.js
@@ -18,14 +18,12 @@ describe('PaletteForm', () => {
       const utils = render(<PaletteForm
         addPalette={mockProps.addPalette}
       />)
-      const select = utils.getByDisplayValue('select')
       const input = utils.getByLabelText('palette-name-input')
       const btn = utils.getByRole('button')
       return {
         input,
         btn,
-        select,
-        ...utils,
+        ...utils
       }
     }
   });
@@ -38,42 +36,57 @@ describe('PaletteForm', () => {
       expect(utils).toMatchSnapshot();
     });
 
-    test('should allow a user to select a project from the drop down')
+    test("should load with initial state of '' in the add palette input", () => {
+      const { input } = setup();
   
-  //   test("should load with initial state of '' in the add project input", () => {
-  //     const { input } = setup();
-  //     const inputValue = input;
-  
-  //     expect(inputValue.textContent).toBe('');
-  //   });
+      expect(input.textContent).toBe('');
+    });
     
-  //   test('should allow a user to input a name', () => {
-  //     const { input } = setup();
-  //     fireEvent.change(input, { target: { value: 'New Project Name'} });
+    test('should allow a user to input a palette name', () => {
+      const { input } = setup();
+      fireEvent.change(input, { target: { value: 'New Palette Name'} });
   
-  //     expect(input.value).toBe('New Project Name')
-  //   });
+      expect(input.value).toBe('New Palette Name');
+    });
   
-  //   test('should reset the input when button is clicked', () => {
-  //     const { input, btn } = setup();
-  //     const inputValue = input;
-  //     fireEvent.change(inputValue, { target: { value: 'New Project Name'} });
-  //     fireEvent.click(btn);
+    test('should reset the input when button is clicked', () => {
+      const { input, btn } = setup();
+      const inputValue = input;
+      fireEvent.change(inputValue, { target: { value: 'New Project Name'} });
+      fireEvent.click(btn);
   
-  //     expect(inputValue.textContent).toBe('')
-  //   });
-  // })
+      expect(inputValue.textContent).toBe('')
+    });
 
-  // describe('mapDispatchToProps', () => {
-
-  //   test('should call mapDispatch with a name when handleLogin is called', () => {
-  //     const mockDispatch = jest.fn();
-  //     const actionToDispatch = addProject({ name: 'Rick' });
-
-  //     const mappedProps = mapDispatchToProps(mockDispatch);
-  //     mappedProps.addProject({ name: 'Rick' });
-
-  //     expect(mockDispatch).toHaveBeenCalledWith(actionToDispatch);
-  //   });
   });
+
+  describe('mapDispatchToProps', () => {
+
+    test('should call mapDispatch with a palette when handleSubmit is called', () => {
+      const mockDispatch = jest.fn();
+      const actionToDispatch = addPalette({ 
+        "name": "Palette Blue", 
+        "project_id": 2, 
+        "color_one": "#87085", 
+        "color_two": "#87085", 
+        "color_three": "#87085", 
+        "color_four": "#87085", 
+        "color_five": "#87085" 
+      });
+
+      const mappedProps = mapDispatchToProps(mockDispatch);
+      mappedProps.addPalette({ 
+        "name": "Palette Blue", 
+        "project_id": 2, 
+        "color_one": "#87085", 
+        "color_two": "#87085", 
+        "color_three": "#87085", 
+        "color_four": "#87085", 
+        "color_five": "#87085" 
+      });
+
+      expect(mockDispatch).toHaveBeenCalledWith(actionToDispatch);
+    });
+  });
+
 });

--- a/src/Containers/PaletteForm/__snapshots__/PaletteForm.test.js.snap
+++ b/src/Containers/PaletteForm/__snapshots__/PaletteForm.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PaletteForm PaletteForm Component should match the snapshot 1`] = `undefined`;

--- a/src/Containers/ProjectForm/ProjectForm.test.js
+++ b/src/Containers/ProjectForm/ProjectForm.test.js
@@ -62,7 +62,7 @@ describe('ProjectForm', () => {
 
   describe('mapDispatchToProps', () => {
 
-    test('should call mapDispatch with a name when handleLogin is called', () => {
+    test('should call mapDispatch with a name when handleSubmit is called', () => {
       const mockDispatch = jest.fn();
       const actionToDispatch = addProject({ name: 'Rick' });
 

--- a/src/Containers/ProjectForm/__snapshots__/ProjectForm.test.js.snap
+++ b/src/Containers/ProjectForm/__snapshots__/ProjectForm.test.js.snap
@@ -1,5 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ProjectForm ProjectForm Component should match the snapshot 1`] = `undefined`;
-
-exports[`ProjectForm should match the snapshot 1`] = `undefined`;


### PR DESCRIPTION
### What does this PR do?
- Adds testing coverage for `PaletteForm` 
- changes name from `handleLogin` to `handleSubmit`

### How to test 
- pull down branch 
- run `npm test` 

### Issues:
- This PR closes no issues 
- I have updated the project board in the BE repo, you can see it [here ](https://github.com/Garrett-Iannuzzi/palette-picker/projects/1)

### Notes:
- The `options` selector in the `PaletteForm` container will need to change at some point so I have not tested for any changes with those 
- For now it looks like this:
![Screen Shot 2020-02-08 at 11 42 46 AM](https://user-images.githubusercontent.com/48968224/74090403-253c8980-4a68-11ea-82c4-2a5a0ac72e83.png)

Thank you for being willing to install the new testing syntax!
@adamsjr8576 

