### PR TITLE
Palettegenerator test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+node_modules
 /.pnp
 .pnp.js
 

--- a/src/Containers/PaletteCard/PaletteCard.js
+++ b/src/Containers/PaletteCard/PaletteCard.js
@@ -4,7 +4,7 @@ import './PaletteCard.scss';
 import images from '../../images/images';
 import { updatePaletteLocked } from '../../actions';
 
-const PaletteCard = ({ locked, hexCode, updatePaletteLocked }) => {
+export const PaletteCard = ({ locked, hexCode, updatePaletteLocked }) => {
   const image = locked? images.locked : images.unlocked;
   return (
     <article className="palette-article" style={{backgroundColor: `${hexCode}`}}>
@@ -20,8 +20,4 @@ const PaletteCard = ({ locked, hexCode, updatePaletteLocked }) => {
   );
 };
 
-export const mapDispatchToProps = dispatch => ({
-  updatePaletteLocked: hexCode => dispatch( updatePaletteLocked(hexCode) )
-});
-
-export default connect(null, mapDispatchToProps)(PaletteCard);
+export default PaletteCard;

--- a/src/Containers/PaletteCard/PaletteCard.js
+++ b/src/Containers/PaletteCard/PaletteCard.js
@@ -9,7 +9,7 @@ export const PaletteCard = ({ locked, hexCode, updatePaletteLocked }) => {
   return (
     <article className="palette-article" style={{backgroundColor: `${hexCode}`}}>
       <div className="palette-info-container">
-        <section tabIndex="1" className="lock-button-section" onClick={() => updatePaletteLocked(hexCode)}>
+        <section tabIndex="1" className="lock-button-section" role="update-palette=locked" onClick={() => updatePaletteLocked(hexCode)}>
           <img src={image} alt="lock icon" className="lock-button-image" />
         </section>
         <section className="hex-code-section">

--- a/src/Containers/PaletteCard/PaletteCard.test.js
+++ b/src/Containers/PaletteCard/PaletteCard.test.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import { PaletteCard } from './PaletteCard';
+import { render, fireEvent } from '@testing-library/react';
+
+describe('PaletteCard', () => {
+  let mockProps, setup;
+
+  test('should match the snapshot when locked is true', () => {
+    mockProps = {
+      locked: true,
+      hexCode: '#11111',
+      updatePaletteLocked: jest.fn()
+    }
+
+    setup = () => {
+      const utils = render(<PaletteCard
+        locked={mockProps.locked}
+        hexCode={mockProps.hexCode}
+        updatePaletteLocked={mockProps.updatePaletteLocked}
+      />)
+      return { utils };
+    }
+
+    const { utils } = setup();
+    expect(utils).toMatchSnapshot();
+  });
+
+  test('should match the snapshot when locked is false', () => {
+    mockProps = {
+      locked: false,
+      hexCode: '#11111',
+      updatePaletteLocked: jest.fn()
+    }
+
+    setup = () => {
+      const utils = render(<PaletteCard
+        locked={mockProps.locked}
+        hexCode={mockProps.hexCode}
+        updatePaletteLocked={mockProps.updatePaletteLocked}
+      />)
+      return { utils };
+    }
+
+    const { utils } = setup();
+    expect(utils).toMatchSnapshot();
+  });
+
+  test('should invoke updatePaletteLocked when button is clicked', () => {
+    mockProps = {
+      locked: false,
+      hexCode: '#11111',
+      updatePaletteLocked: jest.fn()
+    }
+
+    setup = () => {
+      const utils = render(<PaletteCard
+        locked={mockProps.locked}
+        hexCode={mockProps.hexCode}
+        updatePaletteLocked={mockProps.updatePaletteLocked}
+      />);
+      const btn = utils.getByRole('update-palette=locked')
+      return {
+        btn,
+        ...utils
+      };
+    }
+
+    const { btn } = setup();
+    fireEvent.click(btn);
+    expect(mockProps.updatePaletteLocked).toHaveBeenCalledWith(mockProps.hexCode);
+  });
+});

--- a/src/Containers/PaletteCard/__snapshots__/PaletteCard.test.js.snap
+++ b/src/Containers/PaletteCard/__snapshots__/PaletteCard.test.js.snap
@@ -1,0 +1,239 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PaletteCard should match the snapshot when locked is false 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <article
+        class="palette-article"
+      >
+        <div
+          class="palette-info-container"
+        >
+          <section
+            class="lock-button-section"
+            role="update-palette=locked"
+            tabindex="1"
+          >
+            <img
+              alt="lock icon"
+              class="lock-button-image"
+              src="unlock.png"
+            />
+          </section>
+          <section
+            class="hex-code-section"
+          >
+            <p
+              class="hex-p"
+            >
+              #11111
+            </p>
+          </section>
+        </div>
+      </article>
+    </div>
+  </body>,
+  "container": <div>
+    <article
+      class="palette-article"
+    >
+      <div
+        class="palette-info-container"
+      >
+        <section
+          class="lock-button-section"
+          role="update-palette=locked"
+          tabindex="1"
+        >
+          <img
+            alt="lock icon"
+            class="lock-button-image"
+            src="unlock.png"
+          />
+        </section>
+        <section
+          class="hex-code-section"
+        >
+          <p
+            class="hex-p"
+          >
+            #11111
+          </p>
+        </section>
+      </div>
+    </article>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`PaletteCard should match the snapshot when locked is true 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <article
+        class="palette-article"
+      >
+        <div
+          class="palette-info-container"
+        >
+          <section
+            class="lock-button-section"
+            role="update-palette=locked"
+            tabindex="1"
+          >
+            <img
+              alt="lock icon"
+              class="lock-button-image"
+              src="lock.png"
+            />
+          </section>
+          <section
+            class="hex-code-section"
+          >
+            <p
+              class="hex-p"
+            >
+              #11111
+            </p>
+          </section>
+        </div>
+      </article>
+    </div>
+  </body>,
+  "container": <div>
+    <article
+      class="palette-article"
+    >
+      <div
+        class="palette-info-container"
+      >
+        <section
+          class="lock-button-section"
+          role="update-palette=locked"
+          tabindex="1"
+        >
+          <img
+            alt="lock icon"
+            class="lock-button-image"
+            src="lock.png"
+          />
+        </section>
+        <section
+          class="hex-code-section"
+        >
+          <p
+            class="hex-p"
+          >
+            #11111
+          </p>
+        </section>
+      </div>
+    </article>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/src/Containers/PaletteGenerator/PaletteGenerator.js
+++ b/src/Containers/PaletteGenerator/PaletteGenerator.js
@@ -1,10 +1,10 @@
 import { connect } from 'react-redux';
 import React, { useEffect } from 'react';
 import './PaletteGenerator.scss';
-import { addNewPalette } from '../../actions';
+import { addNewPalette, updatePaletteLocked } from '../../actions';
 import PaletteCard from '../PaletteCard/PaletteCard';
 
-const PaletteGenerator = ({ addNewPalette, currentPalette }) => {
+export const PaletteGenerator = ({ addNewPalette, currentPalette, updatePaletteLocked }) => {
   useEffect(() => {
     createPalette();
   }, []);
@@ -12,9 +12,9 @@ const PaletteGenerator = ({ addNewPalette, currentPalette }) => {
   let paletteCards;
 
   if (currentPalette.length) {
-    paletteCards = currentPalette.map(color => {
+    paletteCards = currentPalette.map((color, index) => {
       return (
-        <PaletteCard locked={color.locked} hexCode={color.color} key={color.color} id={color.color} />
+        <PaletteCard locked={color.locked} hexCode={color.color} key={index} id={color.color} updatePaletteLocked={updatePaletteLocked} />
       )
     });
   }
@@ -23,7 +23,7 @@ const PaletteGenerator = ({ addNewPalette, currentPalette }) => {
     const randomColor = `#${Math.floor(Math.random()*16777215).toString(16)}`;
     return randomColor;
   }
-  
+
   const createPalette = () => {
     let palette;
     if (currentPalette.length) {
@@ -56,7 +56,8 @@ const PaletteGenerator = ({ addNewPalette, currentPalette }) => {
 };
 
 export const mapDispatchToProps = dispatch => ({
-  addNewPalette: currentPalette => dispatch( addNewPalette(currentPalette) )
+  addNewPalette: currentPalette => dispatch( addNewPalette(currentPalette) ),
+  updatePaletteLocked: hexCode => dispatch( updatePaletteLocked(hexCode) )
 });
 
 export const mapStateToProps = state => ({

--- a/src/Containers/PaletteGenerator/PaletteGenerator.js
+++ b/src/Containers/PaletteGenerator/PaletteGenerator.js
@@ -36,11 +36,11 @@ export const PaletteGenerator = ({ addNewPalette, currentPalette, updatePaletteL
       });
     } else {
       palette = [
-        {locked: false, color: getRandomColor()},
-        {locked: false, color: getRandomColor()},
-        {locked: false, color: getRandomColor()},
-        {locked: false, color: getRandomColor()},
-        {locked: false, color: getRandomColor()}]
+        {locked: false, color: '#444343'},
+        {locked: false, color: '#6D6D6D'},
+        {locked: false, color: '#9B9B9B'},
+        {locked: false, color: '#C2C2C2'},
+        {locked: false, color: '#DCDCDC'}];
     }
     addNewPalette(palette);
   }
@@ -50,7 +50,7 @@ export const PaletteGenerator = ({ addNewPalette, currentPalette, updatePaletteL
       <section className="palette-card-section">
         {paletteCards}
       </section>
-      <button type="button" className="palette-button" onClick={() => createPalette()}>Create New Palette!</button>
+      <button type="button" className="palette-button" role="create-palette" onClick={() => createPalette()}>Create New Palette!</button>
     </section>
   );
 };

--- a/src/Containers/PaletteGenerator/PaletteGenerator.test.js
+++ b/src/Containers/PaletteGenerator/PaletteGenerator.test.js
@@ -1,0 +1,83 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { PaletteGenerator, mapDispatchToProps, mapStateToProps } from './PaletteGenerator';
+import { PaletteCard } from '../PaletteCard/PaletteCard';
+import { addPalette } from '../../actions/index';
+import { render, fireEvent } from '@testing-library/react';
+
+describe('PaletteGenerator', () => {
+
+  let mockProps, setup;
+
+  // beforeEach(() => {
+  //
+  //   mockProps = {
+  //     addNewPalette: jest.fn(),
+  //     currentPalette:
+  //   }
+  //
+  //   setup = () => {
+  //     const utils = render(<PaletteGenerator
+  //       addProject={mockProps.addProject}
+  //     />)
+  //     const input = utils.getByLabelText('name-project-input')
+  //     const btn = utils.getByRole('button')
+  //     return {
+  //       input,
+  //       btn,
+  //       ...utils,
+  //     }
+  //   }
+  // });
+
+  describe('PalleteGenerator', () => {
+
+    test('should match the snapshot when currentPalette is an empty array', () => {
+      mockProps = {
+        addNewPalette: jest.fn(),
+        currentPalette: []
+      }
+
+      setup = () => {
+        const utils = render(<PaletteGenerator
+          addNewPalette={mockProps.addNewPalette}
+          currentPalette={mockProps.currentPalette}
+        />)
+        return { utils };
+      }
+
+      const { utils } = setup();
+      expect(utils).toMatchSnapshot();
+    });
+
+    test('should match the snapshot when currentPalette is an array of colors', () => {
+      mockProps = {
+        addNewPalette: jest.fn(),
+        currentPalette: [
+          {locked: false, color: '#11111'},
+          {locked: false, color: '#11111'},
+          {locked: false, color: '#11111'},
+          {locked: false, color: '#11111'},
+          {locked: false, color: '#11111'}],
+        updatePaletteLocked: jest.fn()
+      }
+
+      const mockMath = Object.create(global.Math);
+      mockMath.floor = () => 11111;
+      global.Math = mockMath;
+
+      setup = () => {
+        const utils = render(<PaletteGenerator
+          addNewPalette={mockProps.addNewPalette}
+          currentPalette={mockProps.currentPalette}
+        />)
+        return { utils };
+      }
+
+      const { utils } = setup();
+      expect(utils).toMatchSnapshot();
+    });
+
+  });
+
+});

--- a/src/Containers/PaletteGenerator/PaletteGenerator.test.js
+++ b/src/Containers/PaletteGenerator/PaletteGenerator.test.js
@@ -1,8 +1,6 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 import { PaletteGenerator, mapDispatchToProps, mapStateToProps } from './PaletteGenerator';
-import { PaletteCard } from '../PaletteCard/PaletteCard';
-import { addPalette } from '../../actions/index';
+import { addNewPalette, updatePaletteLocked } from '../../actions/index';
 import { render, fireEvent } from '@testing-library/react';
 
 describe('PaletteGenerator', () => {
@@ -159,6 +157,32 @@ describe('PaletteGenerator', () => {
 
       const mappedProps = mapStateToProps(mockState);
       expect(mappedProps).toEqual(expected);
+    });
+  });
+
+  describe('mapDispatchToProps', () => {
+    it('should call dispatch with addNewPalette action ', () => {
+      const currentPalette = [
+        {locked: false, color: '#444343'},
+        {locked: false, color: '#6D6D6D'},
+        {locked: false, color: '#9B9B9B'},
+        {locked: false, color: '#C2C2C2'},
+        {locked: false, color: '#DCDCDC'}];
+      const mockDispatch = jest.fn();
+      const actionToDispatch = addNewPalette(currentPalette);
+      const mappedProps = mapDispatchToProps(mockDispatch);
+
+      mappedProps.addNewPalette(currentPalette);
+      expect(mockDispatch).toHaveBeenCalledWith(actionToDispatch);
+    });
+
+    it('should call dispatch with updatePaletteLocked action', () => {
+      const mockDispatch = jest.fn();
+      const actionToDispatch = updatePaletteLocked('#11111');
+      const mappedProps = mapDispatchToProps(mockDispatch);
+
+      mappedProps.updatePaletteLocked('#11111');
+      expect(mockDispatch).toHaveBeenCalledWith(actionToDispatch);
     });
   });
 });

--- a/src/Containers/PaletteGenerator/PaletteGenerator.test.js
+++ b/src/Containers/PaletteGenerator/PaletteGenerator.test.js
@@ -9,27 +9,6 @@ describe('PaletteGenerator', () => {
 
   let mockProps, setup;
 
-  // beforeEach(() => {
-  //
-  //   mockProps = {
-  //     addNewPalette: jest.fn(),
-  //     currentPalette:
-  //   }
-  //
-  //   setup = () => {
-  //     const utils = render(<PaletteGenerator
-  //       addProject={mockProps.addProject}
-  //     />)
-  //     const input = utils.getByLabelText('name-project-input')
-  //     const btn = utils.getByRole('button')
-  //     return {
-  //       input,
-  //       btn,
-  //       ...utils,
-  //     }
-  //   }
-  // });
-
   describe('PalleteGenerator', () => {
 
     test('should match the snapshot when currentPalette is an empty array', () => {
@@ -70,14 +49,116 @@ describe('PaletteGenerator', () => {
         const utils = render(<PaletteGenerator
           addNewPalette={mockProps.addNewPalette}
           currentPalette={mockProps.currentPalette}
-        />)
-        return { utils };
+          updatePaletteLocked={mockProps.updatePaletteLocked}
+        />);
+        return { utils }
       }
 
       const { utils } = setup();
       expect(utils).toMatchSnapshot();
     });
 
+    test('Should invoke createPalette on button click and when currentPalette is an empty array', () => {
+      mockProps = {
+        addNewPalette: jest.fn(),
+        currentPalette: [],
+        updatePaletteLocked: jest.fn()
+      }
+
+      const mockPaletteInitial = [
+        {locked: false, color: '#444343'},
+        {locked: false, color: '#6D6D6D'},
+        {locked: false, color: '#9B9B9B'},
+        {locked: false, color: '#C2C2C2'},
+        {locked: false, color: '#DCDCDC'}
+      ];
+
+      setup = () => {
+        const utils = render(<PaletteGenerator
+          addNewPalette={mockProps.addNewPalette}
+          currentPalette={mockProps.currentPalette}
+          updatePaletteLocked={mockProps.updatePaletteLocked}
+        />);
+        const btn = utils.getByRole('create-palette')
+        return {
+          btn,
+          ...utils
+        };
+      }
+
+      const { btn } = setup();
+      fireEvent.click(btn);
+      expect(mockProps.addNewPalette).toHaveBeenCalledWith(mockPaletteInitial);
+      expect(mockProps.addNewPalette).toHaveBeenCalledTimes(2);
+    });
+
+    test('Should invoke createPalette on button click and when currentPalette has colors it should reassign them', () => {
+      mockProps = {
+        addNewPalette: jest.fn(),
+        currentPalette: [
+          {locked: false, color: '#444343'},
+          {locked: false, color: '#6D6D6D'},
+          {locked: false, color: '#9B9B9B'},
+          {locked: false, color: '#C2C2C2'},
+          {locked: false, color: '#DCDCDC'}
+        ],
+        updatePaletteLocked: jest.fn()
+      }
+
+      const mockPalette = [
+      { locked: false, color: '#2b67' },
+      { locked: false, color: '#2b67' },
+      { locked: false, color: '#2b67' },
+      { locked: false, color: '#2b67' },
+      { locked: false, color: '#2b67' }
+    ];
+
+      const mockMath = Object.create(global.Math);
+      mockMath.floor = () => 11111;
+      global.Math = mockMath;
+
+      setup = () => {
+        const utils = render(<PaletteGenerator
+          addNewPalette={mockProps.addNewPalette}
+          currentPalette={mockProps.currentPalette}
+          updatePaletteLocked={mockProps.updatePaletteLocked}
+        />);
+        const btn = utils.getByRole('create-palette')
+        return {
+          btn,
+          ...utils
+        };
+      }
+
+      const { btn } = setup();
+      fireEvent.click(btn);
+      expect(mockProps.addNewPalette).toHaveBeenCalledWith(mockPalette);
+      expect(mockProps.addNewPalette).toHaveBeenCalledTimes(2);
+    });
   });
 
+  describe('mapStateToProps', () => {
+    it('should return an object with the currentPalette data', () => {
+      const mockState = {
+        currentPalette: [
+          {locked: false, color: '#444343'},
+          {locked: false, color: '#6D6D6D'},
+          {locked: false, color: '#9B9B9B'},
+          {locked: false, color: '#C2C2C2'},
+          {locked: false, color: '#DCDCDC'}],
+        projects: []
+      };
+      const expected = {
+        currentPalette: [
+          {locked: false, color: '#444343'},
+          {locked: false, color: '#6D6D6D'},
+          {locked: false, color: '#9B9B9B'},
+          {locked: false, color: '#C2C2C2'},
+          {locked: false, color: '#DCDCDC'}]
+      };
+
+      const mappedProps = mapStateToProps(mockState);
+      expect(mappedProps).toEqual(expected);
+    });
+  });
 });

--- a/src/Containers/PaletteGenerator/__snapshots__/PaletteGenerator.test.js.snap
+++ b/src/Containers/PaletteGenerator/__snapshots__/PaletteGenerator.test.js.snap
@@ -19,6 +19,7 @@ Object {
             >
               <section
                 class="lock-button-section"
+                role="update-palette=locked"
                 tabindex="1"
               >
                 <img
@@ -46,6 +47,7 @@ Object {
             >
               <section
                 class="lock-button-section"
+                role="update-palette=locked"
                 tabindex="1"
               >
                 <img
@@ -73,6 +75,7 @@ Object {
             >
               <section
                 class="lock-button-section"
+                role="update-palette=locked"
                 tabindex="1"
               >
                 <img
@@ -100,6 +103,7 @@ Object {
             >
               <section
                 class="lock-button-section"
+                role="update-palette=locked"
                 tabindex="1"
               >
                 <img
@@ -127,6 +131,7 @@ Object {
             >
               <section
                 class="lock-button-section"
+                role="update-palette=locked"
                 tabindex="1"
               >
                 <img
@@ -172,6 +177,7 @@ Object {
           >
             <section
               class="lock-button-section"
+              role="update-palette=locked"
               tabindex="1"
             >
               <img
@@ -199,6 +205,7 @@ Object {
           >
             <section
               class="lock-button-section"
+              role="update-palette=locked"
               tabindex="1"
             >
               <img
@@ -226,6 +233,7 @@ Object {
           >
             <section
               class="lock-button-section"
+              role="update-palette=locked"
               tabindex="1"
             >
               <img
@@ -253,6 +261,7 @@ Object {
           >
             <section
               class="lock-button-section"
+              role="update-palette=locked"
               tabindex="1"
             >
               <img
@@ -280,6 +289,7 @@ Object {
           >
             <section
               class="lock-button-section"
+              role="update-palette=locked"
               tabindex="1"
             >
               <img

--- a/src/Containers/PaletteGenerator/__snapshots__/PaletteGenerator.test.js.snap
+++ b/src/Containers/PaletteGenerator/__snapshots__/PaletteGenerator.test.js.snap
@@ -1,0 +1,451 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PaletteGenerator PalleteGenerator should match the snapshot when currentPalette is an array of colors 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <section
+        class="palette-section"
+      >
+        <section
+          class="palette-card-section"
+        >
+          <article
+            class="palette-article"
+          >
+            <div
+              class="palette-info-container"
+            >
+              <section
+                class="lock-button-section"
+                tabindex="1"
+              >
+                <img
+                  alt="lock icon"
+                  class="lock-button-image"
+                  src="unlock.png"
+                />
+              </section>
+              <section
+                class="hex-code-section"
+              >
+                <p
+                  class="hex-p"
+                >
+                  #11111
+                </p>
+              </section>
+            </div>
+          </article>
+          <article
+            class="palette-article"
+          >
+            <div
+              class="palette-info-container"
+            >
+              <section
+                class="lock-button-section"
+                tabindex="1"
+              >
+                <img
+                  alt="lock icon"
+                  class="lock-button-image"
+                  src="unlock.png"
+                />
+              </section>
+              <section
+                class="hex-code-section"
+              >
+                <p
+                  class="hex-p"
+                >
+                  #11111
+                </p>
+              </section>
+            </div>
+          </article>
+          <article
+            class="palette-article"
+          >
+            <div
+              class="palette-info-container"
+            >
+              <section
+                class="lock-button-section"
+                tabindex="1"
+              >
+                <img
+                  alt="lock icon"
+                  class="lock-button-image"
+                  src="unlock.png"
+                />
+              </section>
+              <section
+                class="hex-code-section"
+              >
+                <p
+                  class="hex-p"
+                >
+                  #11111
+                </p>
+              </section>
+            </div>
+          </article>
+          <article
+            class="palette-article"
+          >
+            <div
+              class="palette-info-container"
+            >
+              <section
+                class="lock-button-section"
+                tabindex="1"
+              >
+                <img
+                  alt="lock icon"
+                  class="lock-button-image"
+                  src="unlock.png"
+                />
+              </section>
+              <section
+                class="hex-code-section"
+              >
+                <p
+                  class="hex-p"
+                >
+                  #11111
+                </p>
+              </section>
+            </div>
+          </article>
+          <article
+            class="palette-article"
+          >
+            <div
+              class="palette-info-container"
+            >
+              <section
+                class="lock-button-section"
+                tabindex="1"
+              >
+                <img
+                  alt="lock icon"
+                  class="lock-button-image"
+                  src="unlock.png"
+                />
+              </section>
+              <section
+                class="hex-code-section"
+              >
+                <p
+                  class="hex-p"
+                >
+                  #11111
+                </p>
+              </section>
+            </div>
+          </article>
+        </section>
+        <button
+          class="palette-button"
+          type="button"
+        >
+          Create New Palette!
+        </button>
+      </section>
+    </div>
+  </body>,
+  "container": <div>
+    <section
+      class="palette-section"
+    >
+      <section
+        class="palette-card-section"
+      >
+        <article
+          class="palette-article"
+        >
+          <div
+            class="palette-info-container"
+          >
+            <section
+              class="lock-button-section"
+              tabindex="1"
+            >
+              <img
+                alt="lock icon"
+                class="lock-button-image"
+                src="unlock.png"
+              />
+            </section>
+            <section
+              class="hex-code-section"
+            >
+              <p
+                class="hex-p"
+              >
+                #11111
+              </p>
+            </section>
+          </div>
+        </article>
+        <article
+          class="palette-article"
+        >
+          <div
+            class="palette-info-container"
+          >
+            <section
+              class="lock-button-section"
+              tabindex="1"
+            >
+              <img
+                alt="lock icon"
+                class="lock-button-image"
+                src="unlock.png"
+              />
+            </section>
+            <section
+              class="hex-code-section"
+            >
+              <p
+                class="hex-p"
+              >
+                #11111
+              </p>
+            </section>
+          </div>
+        </article>
+        <article
+          class="palette-article"
+        >
+          <div
+            class="palette-info-container"
+          >
+            <section
+              class="lock-button-section"
+              tabindex="1"
+            >
+              <img
+                alt="lock icon"
+                class="lock-button-image"
+                src="unlock.png"
+              />
+            </section>
+            <section
+              class="hex-code-section"
+            >
+              <p
+                class="hex-p"
+              >
+                #11111
+              </p>
+            </section>
+          </div>
+        </article>
+        <article
+          class="palette-article"
+        >
+          <div
+            class="palette-info-container"
+          >
+            <section
+              class="lock-button-section"
+              tabindex="1"
+            >
+              <img
+                alt="lock icon"
+                class="lock-button-image"
+                src="unlock.png"
+              />
+            </section>
+            <section
+              class="hex-code-section"
+            >
+              <p
+                class="hex-p"
+              >
+                #11111
+              </p>
+            </section>
+          </div>
+        </article>
+        <article
+          class="palette-article"
+        >
+          <div
+            class="palette-info-container"
+          >
+            <section
+              class="lock-button-section"
+              tabindex="1"
+            >
+              <img
+                alt="lock icon"
+                class="lock-button-image"
+                src="unlock.png"
+              />
+            </section>
+            <section
+              class="hex-code-section"
+            >
+              <p
+                class="hex-p"
+              >
+                #11111
+              </p>
+            </section>
+          </div>
+        </article>
+      </section>
+      <button
+        class="palette-button"
+        type="button"
+      >
+        Create New Palette!
+      </button>
+    </section>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`PaletteGenerator PalleteGenerator should match the snapshot when currentPalette is an empty array 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <section
+        class="palette-section"
+      >
+        <section
+          class="palette-card-section"
+        />
+        <button
+          class="palette-button"
+          type="button"
+        >
+          Create New Palette!
+        </button>
+      </section>
+    </div>
+  </body>,
+  "container": <div>
+    <section
+      class="palette-section"
+    >
+      <section
+        class="palette-card-section"
+      />
+      <button
+        class="palette-button"
+        type="button"
+      >
+        Create New Palette!
+      </button>
+    </section>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/src/Containers/PaletteGenerator/__snapshots__/PaletteGenerator.test.js.snap
+++ b/src/Containers/PaletteGenerator/__snapshots__/PaletteGenerator.test.js.snap
@@ -149,6 +149,7 @@ Object {
         </section>
         <button
           class="palette-button"
+          role="create-palette"
           type="button"
         >
           Create New Palette!
@@ -301,6 +302,7 @@ Object {
       </section>
       <button
         class="palette-button"
+        role="create-palette"
         type="button"
       >
         Create New Palette!
@@ -374,6 +376,7 @@ Object {
         />
         <button
           class="palette-button"
+          role="create-palette"
           type="button"
         >
           Create New Palette!
@@ -390,6 +393,7 @@ Object {
       />
       <button
         class="palette-button"
+        role="create-palette"
         type="button"
       >
         Create New Palette!

--- a/src/Containers/ProjectForm/__snapshots__/ProjectForm.test.js.snap
+++ b/src/Containers/ProjectForm/__snapshots__/ProjectForm.test.js.snap
@@ -1,5 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ProjectForm ProjectForm Component should match the snapshot 1`] = `undefined`;
-
-exports[`ProjectForm should match the snapshot 1`] = `undefined`;


### PR DESCRIPTION
### What does this PR do?
- Adds testing coverage for `PaletteGenerator` and `PaletteCard` 
- PaletteGenerator is using Hooks, and I believe that it is currently succesfully testing that the useEffect method via hooks is working.

### How to test 
- pull down branch 
- run `npm test` 

### Issues:
- This PR closes no issues 
- If a test is failing rather than the test failing in the console it will just run continually and never resolve. This does make writing the tests slightly harder because then you never get an error message if it is failing to help figure out why it is failing. Not sure if that is something that is a result of the new testing library - will want to research further - I will open an issue for it.

### Notes:
- I changed the color palette to be shades of grey whenever the page is loaded and then created random colors on button click. 

@Garrett-Iannuzzi 