### PR TITLE
Palettes forms styling

### DIFF
--- a/src/Components/Header/Header.js
+++ b/src/Components/Header/Header.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import './Header.scss';
 
-const Header = ({ currentPalette }) => {
+export const Header = ({ currentPalette }) => {
   let borderColor;
   if (currentPalette.length) {
     borderColor = currentPalette[0].color;

--- a/src/Components/Header/Header.js
+++ b/src/Components/Header/Header.js
@@ -1,12 +1,21 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import './Header.scss';
 
-const Header = () => {
+const Header = ({ currentPalette }) => {
+  let borderColor;
+  if (currentPalette.length) {
+    borderColor = currentPalette[0].color;
+  }
   return (
-    <header className="main-header">
+    <header className="main-header" style={{borderBottom: `12px groove ${borderColor}`}}>
       <h1 className="header-title">Palette Picker</h1>
     </header>
   )
 }
 
-export default Header;
+export const mapStateToProps = state => ({
+  currentPalette: state.currentPalette
+});
+
+export default connect(mapStateToProps)(Header);

--- a/src/Components/Header/Header.scss
+++ b/src/Components/Header/Header.scss
@@ -3,6 +3,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 0;
+  width: 90%;
 }
 
 .header-title {

--- a/src/Components/Header/Header.test.js
+++ b/src/Components/Header/Header.test.js
@@ -1,19 +1,53 @@
 import React from 'react';
-import Header from './Header'
+import { Header, mapStateToProps } from './Header'
 import { shallow } from 'enzyme';
 
 describe('Header', () => {
 
-  let wrapper
+  let wrapper, mockCurrentPalette;
 
   describe('Header Component', () => {
 
-    beforeEach(() => {
-      wrapper = shallow(<Header />)
+    it('should match the snapshot when currentPalette is an empty array', () => {
+      mockCurrentPalette = [];
+      wrapper = shallow(<Header currentPalette={mockCurrentPalette}/>)
+      expect(wrapper).toMatchSnapshot()
     });
 
-    it('should match the snapshot', () => {
+    it('should match the snapshot when currentPalette is an array of colors', () => {
+      mockCurrentPalette = [
+        {locked: false, color: '#11111'},
+        {locked: false, color: '#11111'},
+        {locked: false, color: '#11111'},
+        {locked: false, color: '#11111'},
+        {locked: false, color: '#11111'}];
+      wrapper = shallow(<Header currentPalette={mockCurrentPalette}/>)
       expect(wrapper).toMatchSnapshot()
+    });
+  });
+
+  describe('mapStateToProps', () => {
+    it('should return an object with the currentPalette data', () => {
+      const mockState = {
+        currentPalette: [
+          {locked: false, color: '#444343'},
+          {locked: false, color: '#6D6D6D'},
+          {locked: false, color: '#9B9B9B'},
+          {locked: false, color: '#C2C2C2'},
+          {locked: false, color: '#DCDCDC'}],
+        projects: []
+      };
+      const expected = {
+        currentPalette: [
+          {locked: false, color: '#444343'},
+          {locked: false, color: '#6D6D6D'},
+          {locked: false, color: '#9B9B9B'},
+          {locked: false, color: '#C2C2C2'},
+          {locked: false, color: '#DCDCDC'}]
+      };
+
+      const mappedProps = mapStateToProps(mockState);
+      expect(mappedProps).toEqual(expected);
     });
   });
 });

--- a/src/Components/Header/__snapshots__/Header.test.js.snap
+++ b/src/Components/Header/__snapshots__/Header.test.js.snap
@@ -1,8 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Header Header Component should match the snapshot 1`] = `
+exports[`Header Header Component should match the snapshot when currentPalette is an array of colors 1`] = `
 <header
   className="main-header"
+  style={
+    Object {
+      "borderBottom": "12px groove #11111",
+    }
+  }
+>
+  <h1
+    className="header-title"
+  >
+    Palette Picker
+  </h1>
+</header>
+`;
+
+exports[`Header Header Component should match the snapshot when currentPalette is an empty array 1`] = `
+<header
+  className="main-header"
+  style={
+    Object {
+      "borderBottom": "12px groove undefined",
+    }
+  }
 >
   <h1
     className="header-title"

--- a/src/Containers/App/App.scss
+++ b/src/Containers/App/App.scss
@@ -2,7 +2,6 @@
   display: flex;
   flex-wrap: wrap;
   text-align: center;
-  background-color: #F2F2F2;
   height: 95vh;
 }
 
@@ -10,11 +9,6 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: space-around;
+  justify-content: space-between;
   width: 30%;
-}
-
-form {
-  display: flex;
-  flex-direction: column;
 }

--- a/src/Containers/PaletteCard/PaletteCard.js
+++ b/src/Containers/PaletteCard/PaletteCard.js
@@ -9,7 +9,15 @@ export const PaletteCard = ({ locked, hexCode, updatePaletteLocked }) => {
   return (
     <article className="palette-article" style={{backgroundColor: `${hexCode}`}}>
       <div className="palette-info-container">
-        <section tabIndex="1" className="lock-button-section" role="update-palette=locked" onClick={() => updatePaletteLocked(hexCode)}>
+        <section tabIndex="1"
+          className="lock-button-section"
+          role="update-palette=locked"
+          onClick={() => updatePaletteLocked(hexCode)}
+          onKeyDown={event => {
+          if (event.key === "Enter") {
+            updatePaletteLocked(hexCode);
+          }
+          }}>
           <img src={image} alt="lock icon" className="lock-button-image" />
         </section>
         <section className="hex-code-section">

--- a/src/Containers/PaletteCard/PaletteCard.js
+++ b/src/Containers/PaletteCard/PaletteCard.js
@@ -4,10 +4,14 @@ import './PaletteCard.scss';
 import images from '../../images/images';
 import { updatePaletteLocked } from '../../actions';
 
-export const PaletteCard = ({ locked, hexCode, updatePaletteLocked }) => {
+export const PaletteCard = ({ locked, rightColor, leftColor, hexCode, updatePaletteLocked }) => {
   const image = locked? images.locked : images.unlocked;
   return (
     <article className="palette-article" style={{backgroundColor: `${hexCode}`}}>
+      <div className="complimentary-colors-container">
+        <div className="color-circle" style={{backgroundColor: `${rightColor}`}}></div>
+        <div className="color-circle" style={{backgroundColor: `${leftColor}`}}></div>
+      </div>
       <div className="palette-info-container">
         <section tabIndex="1"
           className="lock-button-section"

--- a/src/Containers/PaletteCard/PaletteCard.scss
+++ b/src/Containers/PaletteCard/PaletteCard.scss
@@ -5,8 +5,24 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: space-between;
 }
+
+.complimentary-colors-container {
+  display: flex;
+  // flex-direction: column;
+  align-items: center;
+  justify-content: space-around;
+  width: 90%;
+  margin-top: 25px;
+}
+
+.color-circle {
+  width: 75px;
+  height: 75px;
+  border-radius: 50%;
+}
+
 .palette-info-container {
   width: 80%;
   display: flex;
@@ -38,7 +54,10 @@
   outline: none;
 }
 
-.lock-button-section:hover,
+.lock-button-section:hover {
+  animation: transform 4s linear 0s infinite;
+}
+
 .lock-button-section:focus {
   transform: scale(1.05);
 }
@@ -54,4 +73,16 @@
 
 .hex-p {
   margin: 0;
+}
+
+@keyframes transform {
+  0% {
+    border-radius: 50%;
+  }
+  50% {
+    border-radius: 0;
+  }
+  100% {
+    border-radius: 50%;
+  }
 }

--- a/src/Containers/PaletteCard/PaletteCard.scss
+++ b/src/Containers/PaletteCard/PaletteCard.scss
@@ -1,7 +1,7 @@
 .palette-article {
   width: 20%;
   min-width: 120px;
-  height: 650px;
+  height: 95%;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/Containers/PaletteCard/PaletteCard.scss
+++ b/src/Containers/PaletteCard/PaletteCard.scss
@@ -59,7 +59,7 @@
 }
 
 .lock-button-section:focus {
-  transform: scale(1.05);
+  transform: scale(1.1);
 }
 
 .lock-button-section:active {

--- a/src/Containers/PaletteCard/PaletteCard.test.js
+++ b/src/Containers/PaletteCard/PaletteCard.test.js
@@ -9,6 +9,8 @@ describe('PaletteCard', () => {
     mockProps = {
       locked: true,
       hexCode: '#11111',
+      rightColor: '#6D6D6D',
+      leftColor: '#C2C2C2',
       updatePaletteLocked: jest.fn()
     }
 
@@ -16,6 +18,8 @@ describe('PaletteCard', () => {
       const utils = render(<PaletteCard
         locked={mockProps.locked}
         hexCode={mockProps.hexCode}
+        rightColor={mockProps.rightColor}
+        leftColor={mockProps.leftColor}
         updatePaletteLocked={mockProps.updatePaletteLocked}
       />)
       return { utils };
@@ -29,6 +33,8 @@ describe('PaletteCard', () => {
     mockProps = {
       locked: false,
       hexCode: '#11111',
+      rightColor: '#6D6D6D',
+      leftColor: '#C2C2C2',
       updatePaletteLocked: jest.fn()
     }
 
@@ -36,6 +42,8 @@ describe('PaletteCard', () => {
       const utils = render(<PaletteCard
         locked={mockProps.locked}
         hexCode={mockProps.hexCode}
+        rightColor={mockProps.rightColor}
+        leftColor={mockProps.leftColor}
         updatePaletteLocked={mockProps.updatePaletteLocked}
       />)
       return { utils };
@@ -49,6 +57,8 @@ describe('PaletteCard', () => {
     mockProps = {
       locked: false,
       hexCode: '#11111',
+      rightColor: '#6D6D6D',
+      leftColor: '#C2C2C2',
       updatePaletteLocked: jest.fn()
     }
 
@@ -56,6 +66,8 @@ describe('PaletteCard', () => {
       const utils = render(<PaletteCard
         locked={mockProps.locked}
         hexCode={mockProps.hexCode}
+        rightColor={mockProps.rightColor}
+        leftColor={mockProps.leftColor}
         updatePaletteLocked={mockProps.updatePaletteLocked}
       />);
       const btn = utils.getByRole('update-palette=locked')

--- a/src/Containers/PaletteCard/__snapshots__/PaletteCard.test.js.snap
+++ b/src/Containers/PaletteCard/__snapshots__/PaletteCard.test.js.snap
@@ -9,6 +9,16 @@ Object {
         class="palette-article"
       >
         <div
+          class="complimentary-colors-container"
+        >
+          <div
+            class="color-circle"
+          />
+          <div
+            class="color-circle"
+          />
+        </div>
+        <div
           class="palette-info-container"
         >
           <section
@@ -39,6 +49,16 @@ Object {
     <article
       class="palette-article"
     >
+      <div
+        class="complimentary-colors-container"
+      >
+        <div
+          class="color-circle"
+        />
+        <div
+          class="color-circle"
+        />
+      </div>
       <div
         class="palette-info-container"
       >
@@ -128,6 +148,16 @@ Object {
         class="palette-article"
       >
         <div
+          class="complimentary-colors-container"
+        >
+          <div
+            class="color-circle"
+          />
+          <div
+            class="color-circle"
+          />
+        </div>
+        <div
           class="palette-info-container"
         >
           <section
@@ -158,6 +188,16 @@ Object {
     <article
       class="palette-article"
     >
+      <div
+        class="complimentary-colors-container"
+      >
+        <div
+          class="color-circle"
+        />
+        <div
+          class="color-circle"
+        />
+      </div>
       <div
         class="palette-info-container"
       >

--- a/src/Containers/PaletteCard/__snapshots__/PaletteCard.test.js.snap
+++ b/src/Containers/PaletteCard/__snapshots__/PaletteCard.test.js.snap
@@ -13,9 +13,11 @@ Object {
         >
           <div
             class="color-circle"
+            style="background-color: rgb(109, 109, 109);"
           />
           <div
             class="color-circle"
+            style="background-color: rgb(194, 194, 194);"
           />
         </div>
         <div
@@ -54,9 +56,11 @@ Object {
       >
         <div
           class="color-circle"
+          style="background-color: rgb(109, 109, 109);"
         />
         <div
           class="color-circle"
+          style="background-color: rgb(194, 194, 194);"
         />
       </div>
       <div
@@ -152,9 +156,11 @@ Object {
         >
           <div
             class="color-circle"
+            style="background-color: rgb(109, 109, 109);"
           />
           <div
             class="color-circle"
+            style="background-color: rgb(194, 194, 194);"
           />
         </div>
         <div
@@ -193,9 +199,11 @@ Object {
       >
         <div
           class="color-circle"
+          style="background-color: rgb(109, 109, 109);"
         />
         <div
           class="color-circle"
+          style="background-color: rgb(194, 194, 194);"
         />
       </div>
       <div

--- a/src/Containers/PaletteForm/PaletteForm.js
+++ b/src/Containers/PaletteForm/PaletteForm.js
@@ -105,7 +105,7 @@ export const PaletteForm = ({ addPalettes, projects, currentPalette }) => {
         style={{border: `3px solid ${outlineColor}`}}
       />
       <div className='project-form-error-container'>
-        <p className='project-form-error' hidden={!error}>Error: Please Enter a Name and Project</p>
+        <p data-testid='project-form-error' className='project-form-error' hidden={!error}>Error: Please Enter a Name and Project</p>
       </div>
       <button className='select-palette-btn' type='button' onClick={ e => handleSubmit(e) }>Save Palette</button>
     </form>

--- a/src/Containers/PaletteForm/PaletteForm.js
+++ b/src/Containers/PaletteForm/PaletteForm.js
@@ -7,11 +7,18 @@ import { postPalette, getPaletteById } from '../../apiCalls';
 export const PaletteForm = ({ addPalettes, projects, currentPalette }) => {
   const [ newProject, selectNewProject ] = useState('');
   const [ paletteName, setPalette ] = useState('');
+  const [ error, setError ] = useState(false);
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    postNewPalette(paletteName, currentPalette);
-    resetInputs();
+    if (newProject === '' || paletteName === '') {
+      setError(true);
+      resetInputs();
+    } else {
+      postNewPalette(paletteName, currentPalette);
+      resetInputs();
+      setError(false);
+    }
   }
 
   const resetInputs = () => {
@@ -50,7 +57,9 @@ export const PaletteForm = ({ addPalettes, projects, currentPalette }) => {
           .then(palette => {
             addPalettes(palette);
           })
+          .catch(err => console.log(error));
       })
+      .catch(err => console.log(error));
   }
 
   const createProjectOptions = (newProject) => {
@@ -87,7 +96,7 @@ export const PaletteForm = ({ addPalettes, projects, currentPalette }) => {
       </div>
       <input
         data-testid='palette-name-input'
-        placeholder='Name Your Palette'
+        placeholder='Palette Name'
         className='palette-name-input'
         type='text'
         maxLength='30'
@@ -95,6 +104,9 @@ export const PaletteForm = ({ addPalettes, projects, currentPalette }) => {
         onChange={ e => setPalette(e.target.value) }
         style={{border: `3px solid ${outlineColor}`}}
       />
+      <div className='project-form-error-container'>
+        <p className='project-form-error' hidden={!error}>Error: Please Enter a Name and Project</p>
+      </div>
       <button className='select-palette-btn' type='button' onClick={ e => handleSubmit(e) }>Save Palette</button>
     </form>
   )

--- a/src/Containers/PaletteForm/PaletteForm.js
+++ b/src/Containers/PaletteForm/PaletteForm.js
@@ -63,20 +63,28 @@ export const PaletteForm = ({ addPalettes, projects, currentPalette }) => {
     });
   }
 
+  let outlineColor = '#017DF1';
+  if (currentPalette.length) {
+    outlineColor = currentPalette[0].color;
+  }
+
   const options = createProjectOptions(newProject);
   return(
-    <form>
-      <label for='select-project'>Select Project: </label>
-      <select
-        id='select-project'
-        data-testid='select-project'
-        className='project-selector'
-        value={newProject}
-        onChange={ e => selectNewProject(e.target.value) }
-      >
-        <option value="">Select Project</option>
-        {options}
-      </select>
+    <form className='palette-form'>
+      <p className='palette-form-header'>Add Palette To Project: </p>
+      <div className="project-selector-container">
+        <label for='select-project' className='palette-form-label'>Select Project: </label>
+        <select
+          id='select-project'
+          data-testid='select-project'
+          className='project-selector'
+          value={newProject}
+          onChange={ e => selectNewProject(e.target.value) }
+        >
+          <option value="">Please Select</option>
+          {options}
+        </select>
+      </div>
       <input
         data-testid='palette-name-input'
         placeholder='Name Your Palette'
@@ -85,6 +93,7 @@ export const PaletteForm = ({ addPalettes, projects, currentPalette }) => {
         maxLength='30'
         value={paletteName}
         onChange={ e => setPalette(e.target.value) }
+        style={{border: `3px solid ${outlineColor}`}}
       />
       <button className='select-palette-btn' type='button' onClick={ e => handleSubmit(e) }>Save Palette</button>
     </form>

--- a/src/Containers/PaletteForm/PaletteForm.js
+++ b/src/Containers/PaletteForm/PaletteForm.js
@@ -105,7 +105,7 @@ export const PaletteForm = ({ addPalettes, projects, currentPalette }) => {
         style={{border: `3px solid ${outlineColor}`}}
       />
       <div className='project-form-error-container'>
-        <p data-testid='project-form-error' className='project-form-error' hidden={!error}>Error: Please Enter a Name and Project</p>
+        <p data-testid='form-error' className='form-error' hidden={!error}>Error: Please Enter a Name and Project</p>
       </div>
       <button className='select-palette-btn' type='button' onClick={ e => handleSubmit(e) }>Save Palette</button>
     </form>

--- a/src/Containers/PaletteForm/PaletteForm.scss
+++ b/src/Containers/PaletteForm/PaletteForm.scss
@@ -7,8 +7,9 @@
   padding: 15px;
   width: 80%;
   border-radius: 20px;
-  height: 200px;
+  height: 225px;
   background-color: #F2F2F2;
+  margin-bottom: 20px;
 }
 
 .palette-form-header {

--- a/src/Containers/PaletteForm/PaletteForm.scss
+++ b/src/Containers/PaletteForm/PaletteForm.scss
@@ -1,0 +1,66 @@
+.palette-form {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  border: 3px solid black;
+  padding: 15px;
+  width: 80%;
+  border-radius: 20px;
+  height: 200px;
+  background-color: #F2F2F2;
+}
+
+.palette-form-header {
+  font-size: 1.5em;
+  margin: 0;
+}
+
+.palette-form-label {
+  font-size: 1.5em;
+}
+
+.project-selector-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  width: 90%;
+}
+
+.project-selector {
+  font-size: 1em;
+  padding: 10px;
+}
+
+.palette-name-input {
+  width: 70%;
+  font-size: 1em;
+  padding: 10px;
+  border-radius: 10px;
+  outline: none;
+  border: 2px solid black;
+}
+
+.select-palette-btn {
+  font-size: 1.25em;
+  padding: 10px;
+  border-radius: 10px;
+  cursor: pointer;
+  border: 0;
+  background-color: #444343;
+  color: white;
+  outline: none;
+}
+
+.select-palette-btn:hover {
+  box-shadow: 3px 5px #203246;
+}
+
+.select-palette-btn:focus {
+  transform: scale(1.05);
+}
+
+.select-palette-btn:active {
+  transform: translate(3px, 3px);
+  box-shadow: 1px 2px #203246;
+}

--- a/src/Containers/PaletteForm/PaletteForm.test.js
+++ b/src/Containers/PaletteForm/PaletteForm.test.js
@@ -31,7 +31,7 @@ describe('PaletteForm', () => {
       const select = wrapper.getByTestId('select-project')
       const input = wrapper.getByTestId('palette-name-input')
       const btn = wrapper.getByRole('button')
-      const error = wrapper.getByTestId('project-form-error')
+      const error = wrapper.getByTestId('form-error')
       return {
         select,
         input,

--- a/src/Containers/PaletteForm/PaletteForm.test.js
+++ b/src/Containers/PaletteForm/PaletteForm.test.js
@@ -31,10 +31,12 @@ describe('PaletteForm', () => {
       const select = wrapper.getByTestId('select-project')
       const input = wrapper.getByTestId('palette-name-input')
       const btn = wrapper.getByRole('button')
+      const error = wrapper.getByTestId('project-form-error')
       return {
         select,
         input,
         btn,
+        error,
         wrapper
       }
     }
@@ -56,6 +58,7 @@ describe('PaletteForm', () => {
 
     test('should allow a user to input a palette name', () => {
       const { input } = setup();
+
       fireEvent.change(input, { target: { value: 'New Palette Name'} });
 
       expect(input.value).toBe('New Palette Name');
@@ -63,20 +66,52 @@ describe('PaletteForm', () => {
 
     test('should reset the input when button is clicked', () => {
       const { select, input, btn } = setup();
+
       const inputValue = input;
+
       fireEvent.change(select, {target: {value: 'test'}})
       fireEvent.change(inputValue, { target: { value: 'New Project Name'} });
       fireEvent.click(btn);
 
-      expect(inputValue.textContent).toBe('')
+      expect(inputValue.textContent).toBe('');
     });
 
     test('should select a project from the dropdown', () => {
       const { select, wrapper } = setup();
 
       fireEvent.change(select, {target: {value: 'test'}});
+
       expect(wrapper.getByTestId('select-project').value).toBe('test');
       expect(wrapper.getByDisplayValue('test')).toBeInTheDocument();
+    });
+
+    test('should run setError and display errorif button is pushed with nothing in inputs', () => {
+      const { btn, error, wrapper, input } = setup();
+
+      fireEvent.click(btn);
+
+      expect(error.hidden).toEqual(false);
+      expect(input.textContent).toBe('');
+    });
+
+    test('should run setError and display errorif button is pushed with no project selected', () => {
+      const { btn, error, wrapper, select, input } = setup();
+
+      fireEvent.change(select, {target: {value: 'test'}});
+      fireEvent.click(btn);
+
+      expect(error.hidden).toEqual(false);
+      expect(input.textContent).toBe('');
+    });
+
+    test('should run setError and display errorif button is pushed with no palette name', () => {
+      const { btn, error, wrapper, select, input } = setup();
+
+      fireEvent.change(input, { target: { value: 'New Project Name'} });
+      fireEvent.click(btn);
+
+      expect(error.hidden).toEqual(false);
+      expect(input.textContent).toBe('');
     });
 
   });
@@ -107,6 +142,33 @@ describe('PaletteForm', () => {
       });
 
       expect(mockDispatch).toHaveBeenCalledWith(actionToDispatch);
+    });
+  });
+
+  describe('mapStateToProps', () => {
+    it('should return an object with the currentPalette and projects data', () => {
+      const mockState = {
+        currentPalette: [
+          {locked: false, color: '#444343'},
+          {locked: false, color: '#6D6D6D'},
+          {locked: false, color: '#9B9B9B'},
+          {locked: false, color: '#C2C2C2'},
+          {locked: false, color: '#DCDCDC'}],
+        projects: [{name: 'test project', id: 4}],
+        palettes: []
+      };
+      const expected = {
+        currentPalette: [
+          {locked: false, color: '#444343'},
+          {locked: false, color: '#6D6D6D'},
+          {locked: false, color: '#9B9B9B'},
+          {locked: false, color: '#C2C2C2'},
+          {locked: false, color: '#DCDCDC'}],
+          projects: [{name: 'test project', id: 4}],
+      };
+
+      const mappedProps = mapStateToProps(mockState);
+      expect(mappedProps).toEqual(expected);
     });
   });
 

--- a/src/Containers/PaletteForm/__snapshots__/PaletteForm.test.js.snap
+++ b/src/Containers/PaletteForm/__snapshots__/PaletteForm.test.js.snap
@@ -56,8 +56,8 @@ Object {
           class="project-form-error-container"
         >
           <p
-            class="project-form-error"
-            data-testid="project-form-error"
+            class="form-error"
+            data-testid="form-error"
             hidden=""
           >
             Error: Please Enter a Name and Project
@@ -124,8 +124,8 @@ Object {
         class="project-form-error-container"
       >
         <p
-          class="project-form-error"
-          data-testid="project-form-error"
+          class="form-error"
+          data-testid="form-error"
           hidden=""
         >
           Error: Please Enter a Name and Project

--- a/src/Containers/PaletteForm/__snapshots__/PaletteForm.test.js.snap
+++ b/src/Containers/PaletteForm/__snapshots__/PaletteForm.test.js.snap
@@ -5,8 +5,87 @@ Object {
   "asFragment": [Function],
   "baseElement": <body>
     <div>
-      <form>
+      <form
+        class="palette-form"
+      >
+        <p
+          class="palette-form-header"
+        >
+          Add Palette To Project: 
+        </p>
+        <div
+          class="project-selector-container"
+        >
+          <label
+            class="palette-form-label"
+            for="select-project"
+          >
+            Select Project: 
+          </label>
+          <select
+            class="project-selector"
+            data-testid="select-project"
+            id="select-project"
+          >
+            <option
+              value=""
+            >
+              Please Select
+            </option>
+            <option
+              value="test hahahah"
+            >
+              test hahahah
+            </option>
+            <option
+              value="test"
+            >
+              test
+            </option>
+          </select>
+        </div>
+        <input
+          class="palette-name-input"
+          data-testid="palette-name-input"
+          maxlength="30"
+          placeholder="Palette Name"
+          type="text"
+          value=""
+        />
+        <div
+          class="project-form-error-container"
+        >
+          <p
+            class="project-form-error"
+            data-testid="project-form-error"
+            hidden=""
+          >
+            Error: Please Enter a Name and Project
+          </p>
+        </div>
+        <button
+          class="select-palette-btn"
+          type="button"
+        >
+          Save Palette
+        </button>
+      </form>
+    </div>
+  </body>,
+  "container": <div>
+    <form
+      class="palette-form"
+    >
+      <p
+        class="palette-form-header"
+      >
+        Add Palette To Project: 
+      </p>
+      <div
+        class="project-selector-container"
+      >
         <label
+          class="palette-form-label"
           for="select-project"
         >
           Select Project: 
@@ -19,7 +98,7 @@ Object {
           <option
             value=""
           >
-            Select Project
+            Please Select
           </option>
           <option
             value="test hahahah"
@@ -32,59 +111,26 @@ Object {
             test
           </option>
         </select>
-        <input
-          class="palette-name-input"
-          data-testid="palette-name-input"
-          maxlength="30"
-          placeholder="Name Your Palette"
-          type="text"
-          value=""
-        />
-        <button
-          class="select-palette-btn"
-          type="button"
-        >
-          Save Palette
-        </button>
-      </form>
-    </div>
-  </body>,
-  "container": <div>
-    <form>
-      <label
-        for="select-project"
-      >
-        Select Project: 
-      </label>
-      <select
-        class="project-selector"
-        data-testid="select-project"
-        id="select-project"
-      >
-        <option
-          value=""
-        >
-          Select Project
-        </option>
-        <option
-          value="test hahahah"
-        >
-          test hahahah
-        </option>
-        <option
-          value="test"
-        >
-          test
-        </option>
-      </select>
+      </div>
       <input
         class="palette-name-input"
         data-testid="palette-name-input"
         maxlength="30"
-        placeholder="Name Your Palette"
+        placeholder="Palette Name"
         type="text"
         value=""
       />
+      <div
+        class="project-form-error-container"
+      >
+        <p
+          class="project-form-error"
+          data-testid="project-form-error"
+          hidden=""
+        >
+          Error: Please Enter a Name and Project
+        </p>
+      </div>
       <button
         class="select-palette-btn"
         type="button"

--- a/src/Containers/PaletteGenerator/PaletteGenerator.js
+++ b/src/Containers/PaletteGenerator/PaletteGenerator.js
@@ -13,8 +13,28 @@ export const PaletteGenerator = ({ addNewPalette, currentPalette, updatePaletteL
 
   if (currentPalette.length) {
     paletteCards = currentPalette.map((color, index) => {
+      let leftColor;
+      let rightColor;
+      if (index === 0) {
+        leftColor = currentPalette[4].color;
+        rightColor = currentPalette[index+1].color;
+      } else if (index === 4) {
+        leftColor = currentPalette[index-1].color;
+        rightColor = currentPalette[0].color;
+      } else {
+        leftColor = currentPalette[index-1].color;
+        rightColor = currentPalette[index+1].color;
+      }
       return (
-        <PaletteCard locked={color.locked} hexCode={color.color} key={index} id={color.color} updatePaletteLocked={updatePaletteLocked} />
+        <PaletteCard
+          locked={color.locked}
+          rightColor={rightColor}
+          leftColor={leftColor}
+          hexCode={color.color}
+          key={index}
+          id={color.color}
+          updatePaletteLocked={updatePaletteLocked}
+        />
       )
     });
   }

--- a/src/Containers/PaletteGenerator/PaletteGenerator.scss
+++ b/src/Containers/PaletteGenerator/PaletteGenerator.scss
@@ -2,15 +2,15 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: space-between;
   height: 95vh;
   width: 70%;
 }
 
 .palette-card-section {
   display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 650px;
+  align-items: flex-start;
+  height: 87%;
   width: 100%;
 }
 
@@ -19,7 +19,7 @@
   padding: 10px;
   border-radius: 10px;
   border: 0;
-  margin-top: 1em;
+  margin-bottom: 20px;
   outline: none;
   background-color: #616060;
   color: white;

--- a/src/Containers/PaletteGenerator/PaletteGenerator.scss
+++ b/src/Containers/PaletteGenerator/PaletteGenerator.scss
@@ -21,7 +21,7 @@
   border: 0;
   margin-bottom: 20px;
   outline: none;
-  background-color: #616060;
+  background-color: #444343;
   color: white;
   cursor: pointer;
 }

--- a/src/Containers/PaletteGenerator/__snapshots__/PaletteGenerator.test.js.snap
+++ b/src/Containers/PaletteGenerator/__snapshots__/PaletteGenerator.test.js.snap
@@ -15,33 +15,15 @@ Object {
             class="palette-article"
           >
             <div
-              class="palette-info-container"
+              class="complimentary-colors-container"
             >
-              <section
-                class="lock-button-section"
-                role="update-palette=locked"
-                tabindex="1"
-              >
-                <img
-                  alt="lock icon"
-                  class="lock-button-image"
-                  src="unlock.png"
-                />
-              </section>
-              <section
-                class="hex-code-section"
-              >
-                <p
-                  class="hex-p"
-                >
-                  #11111
-                </p>
-              </section>
+              <div
+                class="color-circle"
+              />
+              <div
+                class="color-circle"
+              />
             </div>
-          </article>
-          <article
-            class="palette-article"
-          >
             <div
               class="palette-info-container"
             >
@@ -71,33 +53,15 @@ Object {
             class="palette-article"
           >
             <div
-              class="palette-info-container"
+              class="complimentary-colors-container"
             >
-              <section
-                class="lock-button-section"
-                role="update-palette=locked"
-                tabindex="1"
-              >
-                <img
-                  alt="lock icon"
-                  class="lock-button-image"
-                  src="unlock.png"
-                />
-              </section>
-              <section
-                class="hex-code-section"
-              >
-                <p
-                  class="hex-p"
-                >
-                  #11111
-                </p>
-              </section>
+              <div
+                class="color-circle"
+              />
+              <div
+                class="color-circle"
+              />
             </div>
-          </article>
-          <article
-            class="palette-article"
-          >
             <div
               class="palette-info-container"
             >
@@ -126,6 +90,92 @@ Object {
           <article
             class="palette-article"
           >
+            <div
+              class="complimentary-colors-container"
+            >
+              <div
+                class="color-circle"
+              />
+              <div
+                class="color-circle"
+              />
+            </div>
+            <div
+              class="palette-info-container"
+            >
+              <section
+                class="lock-button-section"
+                role="update-palette=locked"
+                tabindex="1"
+              >
+                <img
+                  alt="lock icon"
+                  class="lock-button-image"
+                  src="unlock.png"
+                />
+              </section>
+              <section
+                class="hex-code-section"
+              >
+                <p
+                  class="hex-p"
+                >
+                  #11111
+                </p>
+              </section>
+            </div>
+          </article>
+          <article
+            class="palette-article"
+          >
+            <div
+              class="complimentary-colors-container"
+            >
+              <div
+                class="color-circle"
+              />
+              <div
+                class="color-circle"
+              />
+            </div>
+            <div
+              class="palette-info-container"
+            >
+              <section
+                class="lock-button-section"
+                role="update-palette=locked"
+                tabindex="1"
+              >
+                <img
+                  alt="lock icon"
+                  class="lock-button-image"
+                  src="unlock.png"
+                />
+              </section>
+              <section
+                class="hex-code-section"
+              >
+                <p
+                  class="hex-p"
+                >
+                  #11111
+                </p>
+              </section>
+            </div>
+          </article>
+          <article
+            class="palette-article"
+          >
+            <div
+              class="complimentary-colors-container"
+            >
+              <div
+                class="color-circle"
+              />
+              <div
+                class="color-circle"
+              />
+            </div>
             <div
               class="palette-info-container"
             >
@@ -173,33 +223,15 @@ Object {
           class="palette-article"
         >
           <div
-            class="palette-info-container"
+            class="complimentary-colors-container"
           >
-            <section
-              class="lock-button-section"
-              role="update-palette=locked"
-              tabindex="1"
-            >
-              <img
-                alt="lock icon"
-                class="lock-button-image"
-                src="unlock.png"
-              />
-            </section>
-            <section
-              class="hex-code-section"
-            >
-              <p
-                class="hex-p"
-              >
-                #11111
-              </p>
-            </section>
+            <div
+              class="color-circle"
+            />
+            <div
+              class="color-circle"
+            />
           </div>
-        </article>
-        <article
-          class="palette-article"
-        >
           <div
             class="palette-info-container"
           >
@@ -229,33 +261,15 @@ Object {
           class="palette-article"
         >
           <div
-            class="palette-info-container"
+            class="complimentary-colors-container"
           >
-            <section
-              class="lock-button-section"
-              role="update-palette=locked"
-              tabindex="1"
-            >
-              <img
-                alt="lock icon"
-                class="lock-button-image"
-                src="unlock.png"
-              />
-            </section>
-            <section
-              class="hex-code-section"
-            >
-              <p
-                class="hex-p"
-              >
-                #11111
-              </p>
-            </section>
+            <div
+              class="color-circle"
+            />
+            <div
+              class="color-circle"
+            />
           </div>
-        </article>
-        <article
-          class="palette-article"
-        >
           <div
             class="palette-info-container"
           >
@@ -284,6 +298,92 @@ Object {
         <article
           class="palette-article"
         >
+          <div
+            class="complimentary-colors-container"
+          >
+            <div
+              class="color-circle"
+            />
+            <div
+              class="color-circle"
+            />
+          </div>
+          <div
+            class="palette-info-container"
+          >
+            <section
+              class="lock-button-section"
+              role="update-palette=locked"
+              tabindex="1"
+            >
+              <img
+                alt="lock icon"
+                class="lock-button-image"
+                src="unlock.png"
+              />
+            </section>
+            <section
+              class="hex-code-section"
+            >
+              <p
+                class="hex-p"
+              >
+                #11111
+              </p>
+            </section>
+          </div>
+        </article>
+        <article
+          class="palette-article"
+        >
+          <div
+            class="complimentary-colors-container"
+          >
+            <div
+              class="color-circle"
+            />
+            <div
+              class="color-circle"
+            />
+          </div>
+          <div
+            class="palette-info-container"
+          >
+            <section
+              class="lock-button-section"
+              role="update-palette=locked"
+              tabindex="1"
+            >
+              <img
+                alt="lock icon"
+                class="lock-button-image"
+                src="unlock.png"
+              />
+            </section>
+            <section
+              class="hex-code-section"
+            >
+              <p
+                class="hex-p"
+              >
+                #11111
+              </p>
+            </section>
+          </div>
+        </article>
+        <article
+          class="palette-article"
+        >
+          <div
+            class="complimentary-colors-container"
+          >
+            <div
+              class="color-circle"
+            />
+            <div
+              class="color-circle"
+            />
+          </div>
           <div
             class="palette-info-container"
           >

--- a/src/Containers/ProjectForm/ProjectForm.js
+++ b/src/Containers/ProjectForm/ProjectForm.js
@@ -54,7 +54,7 @@ export const ProjectForm = ({ addProject, currentPalette }) => {
         style={{border: `3px solid ${outlineColor}`}}
       />
       <div className='project-form-error-container'>
-        <p className='project-form-error' hidden={!error}>Error: Please Enter a Name</p>
+        <p data-testid='form-error' className='form-error' hidden={!error}>Error: Please Enter a Name</p>
       </div>
       <button type='button' className='save-project-btn' role='button' onClick={ e => handleSubmit(e) }>Save Project</button>
     </form>

--- a/src/Containers/ProjectForm/ProjectForm.js
+++ b/src/Containers/ProjectForm/ProjectForm.js
@@ -4,7 +4,7 @@ import { addProject } from '../../actions/index';
 import './ProjectForm.scss';
 import { postProject, getProjectById } from '../../apiCalls';
 
-export const ProjectForm = ({ addProject }) => {
+export const ProjectForm = ({ addProject, currentPalette }) => {
 
   const [ newProject, setNewProject] = useState('');
 
@@ -28,17 +28,23 @@ export const ProjectForm = ({ addProject }) => {
     });
   }
 
+  let outlineColor = '#017DF1';
+  if (currentPalette.length) {
+    outlineColor = currentPalette[0].color;
+  }
+
   return(
     <form className='project-form'>
-      <label for='make-project' className='project-name-label'>Make a new project:</label>
+      <label for='make-project' className='project-name-label'>Make A New Project:</label>
       <input
         className='input-make-project'
         aria-label='name-project-input'
         placeholder='Project Name'
-        maxLength='30'
+        maxLength='20'
         type='text'
         value={newProject}
         onChange={ e => setNewProject(e.target.value) }
+        style={{border: `3px solid ${outlineColor}`}}
       />
       <button type='button' className='save-project-btn' role='button' onClick={ e => handleSubmit(e) }>Save project</button>
     </form>
@@ -49,4 +55,8 @@ export const mapDispatchToProps = dispatch => ({
   addProject: projectName => dispatch( addProject(projectName) )
 });
 
-export default connect(null, mapDispatchToProps)(ProjectForm);
+export const mapStateToProps = state => ({
+  currentPalette: state.currentPalette
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(ProjectForm);

--- a/src/Containers/ProjectForm/ProjectForm.js
+++ b/src/Containers/ProjectForm/ProjectForm.js
@@ -29,8 +29,8 @@ export const ProjectForm = ({ addProject }) => {
   }
 
   return(
-    <form>
-      <label for='make-project'>Make a new project:</label>
+    <form className='project-form'>
+      <label for='make-project' className='project-name-label'>Make a new project:</label>
       <input
         className='input-make-project'
         aria-label='name-project-input'

--- a/src/Containers/ProjectForm/ProjectForm.js
+++ b/src/Containers/ProjectForm/ProjectForm.js
@@ -56,7 +56,7 @@ export const ProjectForm = ({ addProject, currentPalette }) => {
       <div className='project-form-error-container'>
         <p className='project-form-error' hidden={!error}>Error: Please Enter a Name</p>
       </div>
-      <button type='button' className='save-project-btn' role='button' onClick={ e => handleSubmit(e) }>Save project</button>
+      <button type='button' className='save-project-btn' role='button' onClick={ e => handleSubmit(e) }>Save Project</button>
     </form>
   )
 }

--- a/src/Containers/ProjectForm/ProjectForm.js
+++ b/src/Containers/ProjectForm/ProjectForm.js
@@ -6,12 +6,18 @@ import { postProject, getProjectById } from '../../apiCalls';
 
 export const ProjectForm = ({ addProject, currentPalette }) => {
 
-  const [ newProject, setNewProject] = useState('');
+  const [ newProject, setNewProject ] = useState('');
+  const [ error, setError ] = useState(false);
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    postNewProject(newProject);
-    resetInputs();
+    if (newProject === '') {
+      setError(true);
+    } else {
+      postNewProject(newProject);
+      resetInputs();
+      setError(false);
+    }
   }
 
   const resetInputs = () => {
@@ -24,15 +30,16 @@ export const ProjectForm = ({ addProject, currentPalette }) => {
       getProjectById(projectId)
         .then(project => {
           addProject(project[0]);
-        });
-    });
+        })
+        .catch(err => console.log(err))
+    })
+    .catch(err => console.log(err))
   }
 
   let outlineColor = '#017DF1';
   if (currentPalette.length) {
     outlineColor = currentPalette[0].color;
   }
-
   return(
     <form className='project-form'>
       <label for='make-project' className='project-name-label'>Make A New Project:</label>
@@ -46,6 +53,9 @@ export const ProjectForm = ({ addProject, currentPalette }) => {
         onChange={ e => setNewProject(e.target.value) }
         style={{border: `3px solid ${outlineColor}`}}
       />
+      <div className='project-form-error-container'>
+        <p className='project-form-error' hidden={!error}>Error: Please Enter a Name</p>
+      </div>
       <button type='button' className='save-project-btn' role='button' onClick={ e => handleSubmit(e) }>Save project</button>
     </form>
   )

--- a/src/Containers/ProjectForm/ProjectForm.scss
+++ b/src/Containers/ProjectForm/ProjectForm.scss
@@ -24,6 +24,16 @@
   border: 2px solid black;
 }
 
+.project-form-error-container {
+  width: 90%;
+  height: 20px;
+}
+
+.project-form-error {
+  margin: 0;
+  color: red;
+}
+
 .save-project-btn {
   font-size: 1.25em;
   padding: 10px;

--- a/src/Containers/ProjectForm/ProjectForm.scss
+++ b/src/Containers/ProjectForm/ProjectForm.scss
@@ -29,7 +29,7 @@
   height: 20px;
 }
 
-.project-form-error {
+.form-error {
   margin: 0;
   color: red;
 }

--- a/src/Containers/ProjectForm/ProjectForm.scss
+++ b/src/Containers/ProjectForm/ProjectForm.scss
@@ -1,0 +1,49 @@
+.project-form {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  border: 3px solid black;
+  padding: 15px;
+  width: 80%;
+  border-radius: 20px;
+  height: 175px;
+  background-color: #F2F2F2;
+}
+
+.project-name-label {
+  font-size: 1.5em;
+}
+
+.input-make-project {
+  width: 70%;
+  font-size: 1em;
+  padding: 10px;
+  border-radius: 10px;
+  outline: none;
+  border: 2px solid black;
+}
+
+.save-project-btn {
+  font-size: 1.25em;
+  padding: 10px;
+  border-radius: 10px;
+  cursor: pointer;
+  border: 0;
+  background-color: #444343;
+  color: white;
+  outline: none;
+}
+
+.save-project-btn:hover {
+  box-shadow: 3px 5px #203246;
+}
+
+.save-project-btn:focus {
+  transform: scale(1.05);
+}
+
+.save-project-btn:active {
+  transform: translate(3px, 3px);
+  box-shadow: 1px 2px #203246;
+}

--- a/src/Containers/ProjectForm/ProjectForm.test.js
+++ b/src/Containers/ProjectForm/ProjectForm.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { ProjectForm, mapDispatchToProps } from './ProjectForm';
+import { ProjectForm, mapStateToProps, mapDispatchToProps } from './ProjectForm';
 import { addProject } from '../../actions/index';
 import { render, fireEvent } from '@testing-library/react';
 
@@ -11,19 +11,28 @@ describe('ProjectForm', () => {
   beforeEach(() => {
 
     mockProps = {
-      addProject: jest.fn()
+      addProject: jest.fn(),
+      currentPalette: [
+        {locked: false, color: '#11111'},
+        {locked: false, color: '#11111'},
+        {locked: false, color: '#11111'},
+        {locked: false, color: '#11111'},
+        {locked: false, color: '#11111'}]
     }
 
     setup = () => {
-      const utils = render(<ProjectForm 
+      const wrapper = render(<ProjectForm
         addProject={mockProps.addProject}
+        currentPalette={mockProps.currentPalette}
       />)
-      const input = utils.getByLabelText('name-project-input')
-      const btn = utils.getByRole('button')
+      const input = wrapper.getByLabelText('name-project-input')
+      const btn = wrapper.getByRole('button')
+      const error = wrapper.getByTestId('form-error')
       return {
         input,
         btn,
-        ...utils,
+        error,
+        ...wrapper
       }
     }
   });
@@ -31,33 +40,43 @@ describe('ProjectForm', () => {
   describe('ProjectForm Component', () => {
 
     test('should match the snapshot', () => {
-      const { utils } = setup();
-  
-      expect(utils).toMatchSnapshot();
+      const { wrapper } = setup();
+
+      expect(wrapper).toMatchSnapshot();
     });
-  
+
     test("should load with initial state of '' in the add project input", () => {
       const { input } = setup();
       const inputValue = input;
-  
+
       expect(inputValue.textContent).toBe('');
     });
-    
+
     test('should allow a user to input a name', () => {
       const { input } = setup();
       fireEvent.change(input, { target: { value: 'New Project Name'} });
-  
+
       expect(input.value).toBe('New Project Name')
     });
-  
+
     test('should reset the input when button is clicked', () => {
       const { input, btn } = setup();
       const inputValue = input;
       fireEvent.change(inputValue, { target: { value: 'New Project Name'} });
       fireEvent.click(btn);
-  
+
       expect(inputValue.textContent).toBe('')
     });
+
+    test('should run setError and display errorif button is pushed with nothing in inputs', () => {
+      const { btn, error, wrapper, input } = setup();
+
+      fireEvent.click(btn);
+
+      expect(error.hidden).toEqual(false);
+      expect(input.textContent).toBe('');
+    });
+
   })
 
   describe('mapDispatchToProps', () => {
@@ -70,6 +89,31 @@ describe('ProjectForm', () => {
       mappedProps.addProject({ name: 'Rick' });
 
       expect(mockDispatch).toHaveBeenCalledWith(actionToDispatch);
+    });
+  });
+
+  describe('mapStateToProps', () => {
+    it('should return an object with the currentPalette data', () => {
+      const mockState = {
+        currentPalette: [
+          {locked: false, color: '#444343'},
+          {locked: false, color: '#6D6D6D'},
+          {locked: false, color: '#9B9B9B'},
+          {locked: false, color: '#C2C2C2'},
+          {locked: false, color: '#DCDCDC'}],
+        projects: []
+      };
+      const expected = {
+        currentPalette: [
+          {locked: false, color: '#444343'},
+          {locked: false, color: '#6D6D6D'},
+          {locked: false, color: '#9B9B9B'},
+          {locked: false, color: '#C2C2C2'},
+          {locked: false, color: '#DCDCDC'}]
+      };
+
+      const mappedProps = mapStateToProps(mockState);
+      expect(mappedProps).toEqual(expected);
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
- Adds styling to palette generator and forms
- Adds two circles in each color of the palette that pulls the colors from the left and the right reverses them and displays them within. The circles are tied to the locked functionality.
- Adds the ability to tab through the locked buttons and use enter to toggle.
- Adds dynamic color changes to header and forms based on the random palette generator.
- updates tests to pass based on changes made and adds mapStateToProps testing where needed

### How to test?
- Pull down
- run `npm start`
- You should see the changes reflected - PUSH the create new palette button!

### Issues
- This PR closes no issues

### Notes:
- Let me know what you think about the colors changing on the forms - I kind of like the color pop in there that ties it to the current palette.

<img width="1427" alt="Screen Shot 2020-02-11 at 1 13 07 PM" src="https://user-images.githubusercontent.com/49846853/74275271-cf1e4f00-4cd0-11ea-8e8c-c1797bf364e3.png">
